### PR TITLE
Editor settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,14 @@
     "**/.settings": true,
     "**/.factorypath": true,
     "**/*~": true
-  }
+  },
+  "editor.rulers": [
+    120
+  ],
+  "editor.insertSpaces": true,
+  "editor.tabSize": 2,
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": true
+  },
+  "editor.detectIndentation": false
 }


### PR DESCRIPTION
Add some editor settings
- Draw a line at 120 characters to hint not to have excessively long lines
- Indent is 2 spaces
- Don't detect indent from the file, always use 2 spaces
- Automatically organize imports to remove unused imports and keep it clean